### PR TITLE
docker hotspot issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,14 @@ RUN npm config set cache /app/.npm-cache --global
 # Copy node modules and app
 ##COPY --chown=node:node --from=build /app/node_modules /app/node_modules
 ##COPY --chown=node:node --from=build /app/build build
-COPY --from=build /app/package*.json ./
-COPY --from=build /app/node_modules ./node_modules
-COPY --from=build /app/.next ./.next
-COPY --from=build /app/public ./public
-COPY --from=build /app/next.config.ts ./next.config.ts
+COPY --chown=node:node --from=build /app/package*.json ./
+COPY --chown=node:node --from=build /app/node_modules ./node_modules
+COPY --chown=node:node --from=build /app/.next ./.next
+COPY --chown=node:node --from=build /app/public ./public
+COPY --chown=node:node --from=build /app/next.config.ts ./next.config.ts
+
+# Switch to non-root user
+USER node
 
 # Expose port for serve
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,12 +31,12 @@ RUN npm config set cache /app/.npm-cache --global
 # Copy node modules and app
 ##COPY --chown=node:node --from=build /app/node_modules /app/node_modules
 ##COPY --chown=node:node --from=build /app/build build
-COPY --chown=node:node --from=build /app/package*.json ./
-COPY --chown=node:node --from=build /app/node_modules ./node_modules
-COPY --chown=node:node --from=build /app/.next ./.next
-COPY --chown=node:node --from=build /app/public ./public
-COPY --chown=node:node --from=build /app/next.config.ts ./next.config.ts
-RUN chmod -R 555 /app 
+COPY --chown=root:root --chmod=755 --from=build /app/package*.json ./
+COPY --chown=root:root --chmod=755 --from=build /app/node_modules ./node_modules
+COPY --chown=root:root --chmod=755 --from=build /app/.next ./.next
+COPY --chown=root:root --chmod=755 --from=build /app/public ./public
+COPY --chown=root:root --chmod=755 --from=build /app/next.config.ts ./next.config.ts
+
 
 # Switch to non-root user
 USER node

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ COPY --chown=node:node --from=build /app/node_modules ./node_modules
 COPY --chown=node:node --from=build /app/.next ./.next
 COPY --chown=node:node --from=build /app/public ./public
 COPY --chown=node:node --from=build /app/next.config.ts ./next.config.ts
+RUN chmod -R 555 /app 
 
 # Switch to non-root user
 USER node


### PR DESCRIPTION
attacker gets shell inside the container as root (could do anything: read secrets, modify files, etc.) -> add USER node, so app processes runs as an unprivileged user instead = no special permissions