### PR TITLE
Feature/delete event

### DIFF
--- a/app/components/TripCalendar.tsx
+++ b/app/components/TripCalendar.tsx
@@ -1,7 +1,8 @@
 import type { Trip } from "@/types/trip";
 import styles from "@/styles/trips.module.css";
 import { useState } from "react";
-import { Button, ConfigProvider, Form, Input, Modal, TimePicker } from "antd";
+import { Button, ConfigProvider, Form, Input, message, Modal, TimePicker } from "antd";
+import { ApiService } from "@/api/apiService";
 import { Dayjs } from "dayjs";
 import PlaceAutocomplete from "./LocationSearch";
 
@@ -79,6 +80,27 @@ function TripCalendar({ trip }: TripCalendarValues) {
   const [selectedPlace, setSelectedPlace] = useState<google.maps.places.Place | null>(null);
   const [viewingStop, setViewingStop] = useState<{ stop: NewStopValues & { id: string }; date: Date } | null>(null);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+
+  const handleDeleteStop = async () => {
+    if (!viewingStop) return;
+    const key = viewingStop.date.toISOString();
+    setDeleteLoading(true);
+    try {
+      const api = new ApiService();
+      await api.delete(`/trips/${trip.tripId}/events/${viewingStop.stop.id}`);
+      setStops(prev => ({
+        ...prev,
+        [key]: prev[key].filter(s => s.id !== viewingStop.stop.id),
+      }));
+      setConfirmingDelete(false);
+      setViewingStop(null);
+    } catch {
+      message.error("Failed to delete the stop. Please try again.");
+    } finally {
+      setDeleteLoading(false);
+    }
+  };
 
   return (
     <div className={styles.calendarScrollWrapper}>
@@ -220,7 +242,7 @@ function TripCalendar({ trip }: TripCalendarValues) {
             </div>
             <div style={{ display: "flex", justifyContent: "center", gap: 12 }}>
               <Button onClick={() => setConfirmingDelete(false)}>Cancel</Button>
-              <Button danger type="primary">Delete</Button>
+              <Button danger type="primary" loading={deleteLoading} onClick={handleDeleteStop}>Delete</Button>
             </div>
           </div>
         </Modal>

--- a/app/components/TripCalendar.tsx
+++ b/app/components/TripCalendar.tsx
@@ -197,9 +197,9 @@ function TripCalendar({ trip }: TripCalendarValues) {
               <Input.TextArea placeholder={viewingStop?.stop.notes} rows={3} disabled />
             </Form.Item>
             <Form.Item style={{ marginBottom: 0, marginTop: 8 }}>
-              <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <Button danger>Delete</Button>
                 <Button type="primary" >Edit</Button>
-                {/* Add Delete Button */}
               </div>
             </Form.Item>
           </Form>

--- a/app/components/TripCalendar.tsx
+++ b/app/components/TripCalendar.tsx
@@ -78,6 +78,7 @@ function TripCalendar({ trip }: TripCalendarValues) {
 
   const [selectedPlace, setSelectedPlace] = useState<google.maps.places.Place | null>(null);
   const [viewingStop, setViewingStop] = useState<{ stop: NewStopValues & { id: string }; date: Date } | null>(null);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
 
   return (
     <div className={styles.calendarScrollWrapper}>
@@ -198,14 +199,31 @@ function TripCalendar({ trip }: TripCalendarValues) {
             </Form.Item>
             <Form.Item style={{ marginBottom: 0, marginTop: 8 }}>
               <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                <Button danger>Delete</Button>
+                <Button danger onClick={() => setConfirmingDelete(true)}>Delete</Button>
                 <Button type="primary" >Edit</Button>
               </div>
             </Form.Item>
           </Form>
-        </Modal> 
-        
-        
+        </Modal>
+        <Modal
+          open={confirmingDelete}
+          onCancel={() => setConfirmingDelete(false)}
+          footer={null}
+          centered
+        >
+          <div style={{ textAlign: "center", padding: "16px 0" }}>
+            <div style={{ fontSize: 18, fontWeight: 600, color: "#000", marginBottom: 8 }}>
+              Delete &quot;{viewingStop?.stop.title}&quot;?
+            </div>
+            <div style={{ color: "#888", marginBottom: 24 }}>
+              This action cannot be undone.
+            </div>
+            <div style={{ display: "flex", justifyContent: "center", gap: 12 }}>
+              <Button onClick={() => setConfirmingDelete(false)}>Cancel</Button>
+              <Button danger type="primary">Delete</Button>
+            </div>
+          </div>
+        </Modal>
       </ConfigProvider>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add Delete button to the event view modal (#86)
- Add confirmation dialogue before deletion to prevent accidental deletes (#87)
- Call DELETE API on confirmation and remove event from calendar state immediately (#88)

## Changes
- `TripCalendar.tsx`: Added danger Delete button in view modal footer
- `TripCalendar.tsx`: Added confirmation modal with stop title and warning message
- `TripCalendar.tsx`: Added `handleDeleteStop` which calls `DELETE /trips/{tripId}/events/{eventId}`, updates local state on success, and shows error toast on failure
