### PR TITLE
fix share link join for unauthenticated users and direct navigation closes #111

### DIFF
--- a/app/components/AuthForm.tsx
+++ b/app/components/AuthForm.tsx
@@ -69,7 +69,13 @@ export default function AuthForm({ mode }: AuthFormProps) {
       setToken(response.token);
       setUserId(String(response.id));
       setUser(response);
-      router.push("/trips");
+      const joinRedirect = localStorage.getItem("joinRedirect");
+      if (joinRedirect) {
+        localStorage.removeItem("joinRedirect");
+        router.push(joinRedirect);
+      } else {
+        router.push("/trips");
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);  
       if (message.includes("Username already taken. Please choose a different one.")) {

--- a/app/join/[joinToken]/page.tsx
+++ b/app/join/[joinToken]/page.tsx
@@ -40,6 +40,11 @@ const JoinTripPage: React.FC = () => {
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : "Something went wrong.";
+      if (message.includes("401") || message.toLowerCase().includes("unauthorized") || message.toLowerCase().includes("invalid token")) {
+        localStorage.setItem("joinRedirect", `/join/${joinToken}`);
+        router.push("/login");
+        return;
+      }
       alert(message);
     } finally {
       setJoining(false);

--- a/app/trips/[id]/page.tsx
+++ b/app/trips/[id]/page.tsx
@@ -16,28 +16,40 @@ import ShareLink from "@/components/ShareLink";
 import LeaveTrip from "@/components/LeaveTrip";
 import MemberOnlineStatus from "@/components/MemberOnlineStatus";
 import { getAvatarColor } from "@/utils/avatarColors";
+import { useParams } from "next/navigation";
 
 const Profile: React.FC = () => {
   const { isLoading } = useProtectedRoute();
+  const { id } = useParams<{ id: string }>();
 
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [shareLinkOpen, setShareLinkOpen] = useState(false);
   const [LeaveTripOpen, setLeaveTripOpen] = useState(false);
   const [allMembers, setAllMembers] = useState<string[]>([]);
+  const [trip, setTrip] = useState<Trip | null>(null);
 
   const { value: user } = useLocalStorage<User | null>("user", null);
-  const { value: trip } = useLocalStorage<Trip | null>("trip", null);
+  const { value: storedTrip } = useLocalStorage<Trip | null>("trip", null);
 
   const apiService = useApi();
 
   const { handleLogout } = Logout();
 
   useEffect(() => {
+    if (storedTrip && String(storedTrip.tripId) === id) {
+      setTrip(storedTrip);
+    } else {
+      apiService.get<Trip>(`/trips/${id}`)
+        .then(setTrip)
+        .catch((err) => console.error("Failed to fetch trip", err));
+    }
+  }, [id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
     if (!trip?.tripId) return;
 
     const fetchMembers = async () => {
       try {
-        // check for correctness when get members is implemented
         const response = await apiService.get<{ members: string[] }>(`/trips/${trip.tripId}/members`);
         setAllMembers(response.members || []);
       } catch (error) {


### PR DESCRIPTION
- redirect to login (with joinRedirect saved) on 401 in join page
- after register, check joinRedirect and send user back to join flow
- trip detail page now fetches trip from API when not in localStorage